### PR TITLE
headless: backfill reports for resting resumes

### DIFF
--- a/cmd/amplio/main.go
+++ b/cmd/amplio/main.go
@@ -351,6 +351,7 @@ func executeResume(cfg config.Config, runID string) error {
 	}
 	if revived == 0 {
 		slog.Info("run is already at rest; nothing to resume", "run_id", runID)
+		fin.OnMainAgentConcluded(ctx, runID)
 		return nil
 	}
 	slog.Info("run resumed", "run_id", runID, "sessions", revived, "model", run.Config.LLM)

--- a/cmd/amplio/reports_test.go
+++ b/cmd/amplio/reports_test.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"context"
+	"net/url"
+	"path/filepath"
 	"testing"
 
 	"amplio/internal/agent/critic"
@@ -79,5 +81,74 @@ func TestBackfillReports(t *testing.T) {
 	}
 	if len(reports) != 1 {
 		t.Fatalf("second backfill produced %d reports, want 1", len(reports))
+	}
+}
+
+func TestExecuteResume_BackfillsMissingReportForRestingRun(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	config.SetDataDir(dataDir)
+	t.Cleanup(func() { config.SetDataDir("") })
+
+	dbPath := filepath.Join(dataDir, "amplio.db")
+	store, err := sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateRun(ctx, db.RunRecord{
+		RunID:  "r",
+		Config: config.RunConfig{Task: "t"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateSession(ctx, db.SessionRecord{
+		RunID: "r", SessionID: config.RootAgentSessionID,
+		AgentType: "standard_agent", Status: db.SessionConcluded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AdvanceStep(ctx, "r", config.RootAgentSessionID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	const providerName = "resume-test"
+	old, hadOld := providerRegistry[providerName]
+	providerRegistry[providerName] = providerEntry{
+		new: func(_ string, _ int, _, _ url.Values) (llm.Provider, error) {
+			return stubHQ{}, nil
+		},
+	}
+	t.Cleanup(func() {
+		if hadOld {
+			providerRegistry[providerName] = old
+		} else {
+			delete(providerRegistry, providerName)
+		}
+	})
+
+	cfg := config.Config{
+		DB:            dbPath,
+		SystemLLMHQ:   providerName + ":hq",
+		SystemLLMFast: providerName + ":fast",
+	}
+	if err := executeResume(cfg, "r"); err != nil {
+		t.Fatalf("executeResume: %v", err)
+	}
+
+	store, err = sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	reports, err := critic.AllReports(ctx, store, "r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("resume produced %d reports, want 1", len(reports))
 	}
 }


### PR DESCRIPTION
## Summary

Ensure `headless resume` backfills a missing run report when the run is already at rest.

A run can reach `concluded` and then terminate before the normal headless report finalizer runs. In that state, `headless resume` currently sees that there are no sessions to revive and returns immediately, leaving the report missing.

This change invokes the existing idempotent finalizer before returning from the `revived == 0` path.

## Reproduction

Starting from a persisted headless run whose root session is already `concluded` but has no report:

```text
current main:
headless resume <run-id>
-> run is already at rest
-> 0 reports
-> 0 HQ calls

patched:
headless resume <run-id>
-> run is already at rest
-> 1 report
-> 1 HQ call
```

Running the patched resume a second time keeps the report count at 1 and makes no additional HQ call.

A cancelled root session remains a no-op: 0 reports and 0 HQ calls.

## Validation

- spawned parent and patched `amplio` binaries for a process-level A/B
- persisted SQLite run state and a local OpenAI-compatible critic endpoint
- second-resume idempotency check
- cancelled-run negative case
- focused regression repeated 20x
- focused race coverage
- `cmd/amplio` shuffled tests x3
- full `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run ./...`
- `go build ./...`
