### PR TITLE
eventloop: don't conclude on an unreadable event count

### DIFF
--- a/internal/agent/eventloop/eventloop.go
+++ b/internal/agent/eventloop/eventloop.go
@@ -743,8 +743,18 @@ func (a *EventLoopAgent) loop(ctx context.Context, needsAdvance bool) error {
 		// always processes what's queued. So e.g. a child_result(crashed) that
 		// lands as we're about to conclude pulls us back for one more turn to see
 		// it, which is intended.
-		nextStepCount, _ := a.env.Store.GetEventCount(ctx, a.env.RunID, a.cfg.SessionID,
+		nextStepCount, err := a.env.Store.GetEventCount(ctx, a.env.RunID, a.cfg.SessionID,
 			db.EventFilter{StartStep: &newStep})
+		if err != nil {
+			// A failed count is NOT a count of zero. Concluding here is terminal
+			// and unrecoverable (db.IsSpine excludes concluded, so RecoverRun
+			// skips the session), so an unreadable queue must never be treated as
+			// an empty one. recordFailure already routes both reachable causes
+			// correctly: a cancelled ctx (shutdown/cancel) returns without
+			// writing, leaving the status for recovery, and a db.ErrStore error
+			// leaves the session ongoing-but-dead for Recover.
+			return a.recordFailure(ctx, fmt.Errorf("count events arrived during generation: %w", err))
+		}
 		if nextStepCount > 0 {
 			a.logger.Debug("events arrived during generation, continuing")
 			continue

--- a/internal/agent/eventloop/shutdown_conclude_test.go
+++ b/internal/agent/eventloop/shutdown_conclude_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventloop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"amplio/internal/db"
+	"amplio/internal/event"
+	"amplio/internal/llm"
+	"amplio/internal/session"
+	"amplio/internal/tool"
+	"amplio/internal/workspace/plain"
+)
+
+// cancelAtCheck cancels the session context once FinalizeStep commits, which is
+// the window shutdown opens: session.Registry.CancelAll ctx-cancels but leaves
+// DB status alone so RecoverRun can resume. The wrapped store is the real one
+// and no error is injected; only the timing of the cancel is forced.
+type cancelAtCheck struct {
+	db.Store
+	cancel    context.CancelFunc
+	runID     string
+	sessionID string
+	once      sync.Once
+}
+
+func (s *cancelAtCheck) FinalizeStep(ctx context.Context, runID, sessionID string, step int, evts []event.Event) error {
+	if err := s.Store.FinalizeStep(ctx, runID, sessionID, step, evts); err != nil {
+		return err
+	}
+	s.once.Do(func() {
+		// current_step is already bumped here, so this lands at exactly the step
+		// the during-generation check looks at.
+		_, _ = s.Store.AppendEvent(context.Background(), s.runID, s.sessionID,
+			&event.ChildResultEvent{ChildSessionID: "child-1", Verdict: db.SessionCrashed})
+		s.cancel()
+	})
+	return nil
+}
+
+// failCount fails the during-generation count once, with the error shape
+// db.Tag produces at the store boundary. Injected, unlike cancelAtCheck: it
+// covers recordFailure's db.ErrStore branch, which the shutdown case does not
+// reach. The loop's only GetEventCount call site is that check.
+type failCount struct {
+	db.Store
+	once sync.Once
+}
+
+func (s *failCount) GetEventCount(ctx context.Context, runID, sessionID string, opts db.EventFilter) (int, error) {
+	first := false
+	s.once.Do(func() { first = true })
+	if first {
+		return 0, fmt.Errorf("%w: %w", db.ErrStore, errors.New("transient read failure"))
+	}
+	return s.Store.GetEventCount(ctx, runID, sessionID, opts)
+}
+
+// runTurn runs one bare no-tool turn (the shape that concludes an autonomous
+// agent) and reports the session's persisted status.
+func runTurn(t *testing.T, ctx context.Context, store db.Store, runID string, reg *session.Registry) string {
+	t.Helper()
+	ag := newT(testCfg{
+		RunID: runID, SessionID: "main-agent", Task: "work",
+		SystemPrompt: "You are a helpful agent.",
+		LLM: &llm.MockProvider{Model: "test-model",
+			Responses: []llm.Response{{Content: "Done for now.", StopReason: "end_turn"}}},
+		Store: store, Registry: reg, Tools: []*tool.Tool{}, Workspace: plain.New("/tmp"),
+	})
+	_ = ag.Run(ctx)
+	sess, err := store.GetSession(context.Background(), runID, "main-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sess.Status
+}
+
+// A shutdown landing on the during-generation check must not conclude the
+// session. Concluding is terminal: db.IsSpine excludes concluded, so RecoverRun
+// skips the session and the queued event is lost.
+func TestEventLoop_ShutdownAtConclusionCheckLeavesSessionRecoverable(t *testing.T) {
+	store, runID, reg := testSetup(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w := &cancelAtCheck{Store: store, cancel: cancel, runID: runID, sessionID: "main-agent"}
+
+	if got := runTurn(t, ctx, w, runID, reg); got != db.SessionOngoing {
+		t.Fatalf("status = %q, want %q: shutdown must leave the session recoverable", got, db.SessionOngoing)
+	}
+}
+
+// A failed event count is not a count of zero: an unreadable queue must leave
+// the session ongoing-but-dead for Recover rather than concluding.
+func TestEventLoop_StoreErrorAtConclusionCheckLeavesSessionRecoverable(t *testing.T) {
+	store, runID, reg := testSetup(t)
+	w := &failCount{Store: store}
+
+	if got := runTurn(t, context.Background(), w, runID, reg); got != db.SessionOngoing {
+		t.Fatalf("status = %q, want %q: a store error must not read as an empty queue", got, db.SessionOngoing)
+	}
+}


### PR DESCRIPTION
## Summary

The during-generation event count discarded its error, so a failed read was indistinguishable from an empty queue and the agent concluded on it.

## Why

An autonomous agent ending a turn with no tool calls checks whether events arrived while the model was generating, then concludes. That check dropped `GetEventCount`'s error, so a failed read became a count of zero.

Concluding is terminal. `db.IsSpine` excludes `concluded`, so `RecoverRun` never resumes the session and an environment notification cannot revive it. Anything queued at the bumped step is dropped, and the parent gets a `concluded` verdict for work that never finished.

Shutdown reaches it. `session.Registry.CancelAll` only ctx-cancels and leaves DB status alone so `RecoverRun` can resume. A cancel landing between `FinalizeStep` and the check makes `GetEventCount` return `context.Canceled`, and `conclude()` writes with `context.Background()`, so the dead context does not stop the terminal write. A transient store read failure gives the same zero.

## Implementation

- check `GetEventCount`'s error instead of discarding it
- route it through `recordFailure`, as every other store call in `loop` does
- a cancelled ctx returns without writing; a `db.ErrStore` error leaves the session ongoing-but-dead for `Recover`

## Validation

### Interrupted headless runs

`amplio headless run` against `deepseek-v4-flash`, interrupted with SIGINT (what Ctrl-C sends) at a swept delay after the model's completion reaches the agent. Identical invocation and identical interrupt schedule on both binaries, so only the patch differs. 27 runs, 3 per delay, final status read from each run's sqlite DB.

```
delay_us    upstream dd403f3    patched        n
      0     ongoing             ongoing      3/3
    100     ongoing             ongoing      3/3
    250     ongoing             ongoing      3/3
    500     ongoing             ongoing      3/3
   1000     ongoing             ongoing      3/3
   2000     ongoing             ongoing      3/3
   5000     concluded           ongoing      2/3   <- window
   5000     ongoing             ongoing      1/3
  10000     concluded           concluded    3/3
  20000     concluded           concluded    3/3
```

Below 5 ms the interrupt arrives before the check, `FinalizeStep` fails, and both binaries leave the session `ongoing`. At 10 ms and above the run has already concluded on its own. At 5 ms the interrupt lands inside the window and the two diverge:

```
UPSTREAM  dd403f3    final session status: concluded
  INFO  interrupted, cancelling run
  (no further agent output; db.IsSpine excludes concluded, so RecoverRun
   would never resume this run)

PATCHED   c826171    final session status: ongoing
  INFO  interrupted, cancelling run
  ERROR agent failure session=main-agent
        error="count events arrived during generation: db store: context canceled"
```

An uninterrupted control run on the same setup concludes normally, so the divergence comes from the interrupt rather than the harness.

### Tests

Two regression tests, one per cause, fail on `dd403f3` and pass with the patch:

```
go test ./internal/agent/eventloop \
  -run 'TestEventLoop_(ShutdownAtConclusionCheckLeavesSessionRecoverable|StoreErrorAtConclusionCheckLeavesSessionRecoverable)' \
  -count=1 -v

BEFORE   --- FAIL: TestEventLoop_ShutdownAtConclusionCheckLeavesSessionRecoverable
         --- FAIL: TestEventLoop_StoreErrorAtConclusionCheckLeavesSessionRecoverable
AFTER    --- PASS: TestEventLoop_ShutdownAtConclusionCheckLeavesSessionRecoverable
         --- PASS: TestEventLoop_StoreErrorAtConclusionCheckLeavesSessionRecoverable
```

Focused x50 and `-race` x20 clean; full tests, vet, lint and build pass on go1.26.2.

The shutdown test forces a real interleaving against the real sqlite store, with nothing stubbed and no error injected. The store-error test does inject its error, noted as such in the file, to cover the `db.ErrStore` branch that the shutdown case does not reach.
